### PR TITLE
スクリプトソースの改行コードがLF以外でも意図した挙動をするよう修正

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -6,6 +6,7 @@ use regex::Regex;
 
 use crate::config::{Config, Script};
 use crate::include::process_includes;
+use crate::text_utils::read_text;
 use crate::ui_control::{apply_ui_blocks, parse_ui_blocks};
 
 pub fn build_all(config: &Config, out_dir: &Path) -> anyhow::Result<()> {
@@ -23,7 +24,7 @@ fn build_script(script: &Script, config: &Config, out_dir: &Path) -> anyhow::Res
 
     for source in &script.sources {
         let src_path = PathBuf::from(&source.path);
-        let content = fs::read_to_string(&src_path).map_err(|e| {
+        let content = read_text(&src_path).map_err(|e| {
             anyhow::anyhow!("{} の読み込みに失敗しました: {}", src_path.display(), e)
         })?;
 

--- a/src/include.rs
+++ b/src/include.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::text_utils::read_text;
+
 pub fn process_includes(
     content: &str,
     base_dir: &Path,
@@ -34,7 +36,7 @@ pub fn process_includes(
 
                 visited.insert(canonical.clone());
 
-                let include_content = fs::read_to_string(&canonical).map_err(|e| {
+                let include_content = read_text(&canonical).map_err(|e| {
                     format!(
                         "Failed to read included file {}: {}",
                         canonical.display(),
@@ -68,12 +70,14 @@ mod tests {
 
     use std::path::PathBuf;
 
-    use crate::common::read_fixture;
+    use crate::common::get_fixture_path;
 
     #[test]
     fn test_nested_includes() {
-        let input = read_fixture("include_main.lua");
-        let expected = read_fixture("include_main_out.lua");
+        let input_path = get_fixture_path("include_main.lua");
+        let input = read_text(&input_path).unwrap();
+        let expected_path = get_fixture_path("include_main_out.lua");
+        let expected = read_text(&expected_path).unwrap();
 
         let base_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
         let mut visited = HashSet::new();
@@ -87,7 +91,8 @@ mod tests {
 
     #[test]
     fn test_cycle_includes() {
-        let input = read_fixture("include_cycle_a.lua");
+        let input_path = get_fixture_path("include_cycle_a.lua");
+        let input = read_text(&input_path).unwrap();
 
         let base_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
         let mut visited = HashSet::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod config_loader;
 pub mod include;
 pub mod install;
+pub mod text_utils;
 pub mod ui_control;
 
 #[cfg(test)]

--- a/src/text_utils.rs
+++ b/src/text_utils.rs
@@ -1,0 +1,24 @@
+use std::fs;
+use std::io;
+use std::path::Path;
+
+pub fn read_text(path: &Path) -> io::Result<String> {
+    let text = fs::read_to_string(path)?;
+    Ok(text.replace("\r\n", "\n").replace('\r', "\n"))
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_read_text() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path();
+        fs::write(path, "\r,\n,\r\n").unwrap();
+
+        let output = read_text(path).unwrap();
+        assert_eq!(output, "\n,\n,\n");
+    }
+}

--- a/src/ui_control.rs
+++ b/src/ui_control.rs
@@ -314,7 +314,7 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    use crate::common::read_fixture;
+    use crate::{common::get_fixture_path, text_utils::read_text};
 
     #[test]
     fn test_parse_ui_blocks_select() {
@@ -358,7 +358,8 @@ local eye = 1
         #[case] start_line: usize,
         #[case] end_line: usize,
     ) {
-        let input = read_fixture(input_file);
+        let input_path = get_fixture_path(input_file);
+        let input = read_text(&input_path).unwrap();
         let blocks = parse_ui_blocks(&input);
 
         assert_eq!(blocks.len(), 1);

--- a/tests/build_test.rs
+++ b/tests/build_test.rs
@@ -1,5 +1,6 @@
 use aulua::build::build_all;
 use aulua::config_loader::load_config;
+use aulua::text_utils::read_text;
 use std::fs;
 use std::path::Path;
 
@@ -14,7 +15,7 @@ fn test_basic_build() {
 
     build_all(&config, out_dir).unwrap();
 
-    let result = fs::read_to_string(output_file).unwrap();
+    let result = read_text(&output_file).unwrap();
     let expect = r#"@スクリプト1
 print("hello from script1")
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,9 +1,7 @@
-use std::fs;
 use std::path::PathBuf;
 
-pub fn read_fixture(file: &str) -> String {
-    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+pub fn get_fixture_path(file: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures")
-        .join(file);
-    fs::read_to_string(&path).unwrap_or_else(|_| panic!("failed to read: {:?}", &path))
+        .join(file)
 }

--- a/tests/ui_control_test.rs
+++ b/tests/ui_control_test.rs
@@ -2,9 +2,12 @@ mod common;
 
 use rstest::rstest;
 
-use aulua::ui_control::{apply_ui_blocks, parse_ui_blocks};
+use aulua::{
+    text_utils::read_text,
+    ui_control::{apply_ui_blocks, parse_ui_blocks},
+};
 
-use common::read_fixture;
+use common::get_fixture_path;
 
 #[rstest]
 #[case::select_1("ui_control_select_1_in.anm2", "ui_control_select_1_out.anm2")]
@@ -29,8 +32,10 @@ use common::read_fixture;
     "ui_control_value_table_1_out.anm2"
 )]
 fn test_parse_apply(#[case] input_file: &str, #[case] expected_file: &str) {
-    let input = read_fixture(input_file);
-    let expected = read_fixture(expected_file);
+    let input_path = get_fixture_path(input_file);
+    let input = read_text(&input_path).unwrap();
+    let expected_path = get_fixture_path(expected_file);
+    let expected = read_text(&expected_path).unwrap();
     let blocks = parse_ui_blocks(&input);
     let output = apply_ui_blocks(&input, &blocks);
     assert_eq!(output, expected);


### PR DESCRIPTION
Issue #3 の対応

スクリプトソースがLF以外 (CRLF, CR) だった時に意図した挙動にならない場合があったため、スクリプトソース読み込み時に改行コードをLFに正規化するよう修正した。