### PR TITLE
設定ファイルのスキーマを出力する機能を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,3 +32,9 @@ jobs:
 
       - name: Test
         run: cargo test --workspace
+
+      - name: Check if generated schema matches committed file
+        run: |
+          mkdir tmp
+          cargo run --release -- schema -o ./tmp/aulua.schema.json
+          git diff --no-index --exit-code ./schema/aulua.schema.json ./tmp/aulua.schema.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,9 @@ dependencies = [
  "clap",
  "regex",
  "rstest",
+ "schemars",
  "serde",
+ "serde_json",
  "serde_yaml_ng",
  "tempfile",
  "thiserror",
@@ -138,6 +140,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "equivalent"
@@ -332,6 +340,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +453,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,6 +501,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,9 @@ license = "MIT"
 anyhow = "1.0.98"
 clap = { version = "4.5.41", features = ["derive"] }
 regex = "1.11.1"
+schemars = "1.0.4"
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.140"
 serde_yaml_ng = "0.10.0"
 thiserror = "2.0.12"
 

--- a/schema/aulua.schema.json
+++ b/schema/aulua.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Config",
+  "description": "全体の設定ファイル構造",
+  "type": "object",
+  "properties": {
+    "build": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Build"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "install": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Install"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "project": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/Project"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "scripts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Script"
+      }
+    }
+  },
+  "required": [
+    "scripts"
+  ],
+  "$defs": {
+    "Build": {
+      "description": "`build` セクション",
+      "type": "object",
+      "properties": {
+        "out_dir": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Install": {
+      "description": "`install` セクション",
+      "type": "object",
+      "properties": {
+        "out_dir": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Project": {
+      "description": "`project` セクション",
+      "type": "object",
+      "properties": {
+        "variables": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Script": {
+      "description": "各出力スクリプト単位の設定",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ScriptSource"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "sources"
+      ]
+    },
+    "ScriptSource": {
+      "description": "各スクリプトソースの設定",
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "variables": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
+  }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,10 @@
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// 全体の設定ファイル構造
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct Config {
     pub project: Option<Project>,
     pub build: Option<Build>,
@@ -34,32 +35,32 @@ impl Config {
 }
 
 /// `project` セクション
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct Project {
     pub variables: Option<HashMap<String, String>>,
 }
 
 /// `build` セクション
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct Build {
     pub out_dir: Option<String>,
 }
 
 /// `install` セクション
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct Install {
     pub out_dir: Option<String>,
 }
 
 /// 各出力スクリプト単位の設定
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct Script {
     pub name: String,
     pub sources: Vec<ScriptSource>,
 }
 
 /// 各スクリプトソースの設定
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct ScriptSource {
     pub path: String,
     pub label: Option<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod config_loader;
 pub mod include;
 pub mod install;
+pub mod schema;
 pub mod text_utils;
 pub mod ui_control;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,11 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 
 use aulua::build::build_all;
 use aulua::config_loader::load_config;
 use aulua::install::install_all;
+use aulua::schema::generate_config_schema;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -20,6 +23,12 @@ enum Commands {
         /// ファイルはコピーせず、処理内容だけ表示する
         #[arg(long)]
         dry_run: bool,
+    },
+    /// スキーマファイルを生成する
+    Schema {
+        /// 出力先ファイルのパスを指定する
+        #[arg(short, long, value_name = "file", default_value = "aulua.schema.json")]
+        output: PathBuf,
     },
 }
 
@@ -40,6 +49,9 @@ fn main() {
                 dry_run,
             )
             .expect("インストールに失敗しました");
+        }
+        Commands::Schema { output } => {
+            generate_config_schema(&output).expect("スキーマ生成に失敗しました");
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,29 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::anyhow;
+use schemars::schema_for;
+
+use crate::config::Config;
+
+pub fn generate_config_schema(path: &Path) -> anyhow::Result<()> {
+    let schema = schema_for!(Config);
+    let schema_json = serde_json::to_string_pretty(&schema)
+        .map_err(|e| anyhow!("スキーマの生成に失敗しました: {e}"))?;
+    fs::write(path, schema_json)
+        .map_err(|e| anyhow!("スキーマファイルの書き込みに失敗しました: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_generate_config_schema() {
+        let file = NamedTempFile::new().unwrap();
+        let path = file.path();
+        generate_config_schema(path).expect("スキーマの生成に失敗しました");
+    }
+}


### PR DESCRIPTION
Issue #2 の対応

`aulua schema -o <file>` で 設定ファイル `aulua.yaml` 用のJSONスキーマを出力する機能を追加した。
スキーマファイルはリポジトリにコミットしてあるので、利用者はローカルで出力したスキーマかリモートリポジトリのファイルかどちらを参照しても良い。
コミットしてあるスキーマファイルが最新のものになっているかどうかはCIワークフローで確認する。