### PR TITLE
feat: フォルダ選択項目の対応を追加

### DIFF
--- a/src/ui_control.rs
+++ b/src/ui_control.rs
@@ -7,6 +7,7 @@ pub enum UiControlKind {
     Check,
     Color,
     File,
+    Folder,
     Font,
     Figure,
     Text,
@@ -58,6 +59,10 @@ pub fn parse_ui_blocks(source: &str) -> Vec<UiControlBlock> {
             blocks.push(block);
         } else if let Some(label) = line.strip_prefix("---$file:")
             && let Some(block) = parse_file_block(i, label, &mut lines)
+        {
+            blocks.push(block);
+        } else if let Some(label) = line.strip_prefix("---$folder:")
+            && let Some(block) = parse_ui_block_no_meta(UiControlKind::Folder, i, label, &mut lines)
         {
             blocks.push(block);
         } else if let Some(label) = line.strip_prefix("---$font:")
@@ -279,6 +284,9 @@ pub fn apply_ui_blocks(source: &str, blocks: &[UiControlBlock]) -> String {
             }
             UiControlKind::File => {
                 format!("--file@{}:{}", block.var_name, block.label)
+            }
+            UiControlKind::Folder => {
+                format!("--folder@{}:{}", block.var_name, block.label)
             }
             UiControlKind::Font => {
                 format!(

--- a/tests/fixtures/ui_control_folder_1_in.anm2
+++ b/tests/fixtures/ui_control_folder_1_in.anm2
@@ -1,0 +1,2 @@
+---$folder:フォルダ
+local path = ""

--- a/tests/fixtures/ui_control_folder_1_out.anm2
+++ b/tests/fixtures/ui_control_folder_1_out.anm2
@@ -1,0 +1,1 @@
+--folder@path:フォルダ

--- a/tests/ui_control_test.rs
+++ b/tests/ui_control_test.rs
@@ -22,6 +22,7 @@ use common::get_fixture_path;
 #[case::check_1("ui_control_check_1_in.anm2", "ui_control_check_1_out.anm2")]
 #[case::color_1("ui_control_color_1_in.anm2", "ui_control_color_1_out.anm2")]
 #[case::file_1("ui_control_file_1_in.anm2", "ui_control_file_1_out.anm2")]
+#[case::folder_1("ui_control_folder_1_in.anm2", "ui_control_folder_1_out.anm2")]
 #[case::font_1("ui_control_font_1_in.anm2", "ui_control_font_1_out.anm2")]
 #[case::figure_1("ui_control_figure_1_in.anm2", "ui_control_figure_1_out.anm2")]
 #[case::text_1("ui_control_text_1_in.anm2", "ui_control_text_1_out.anm2")]


### PR DESCRIPTION
Issue #16 の対応
AviUtl ExEdit2 beta28aで追加されたフォルダ選択項目へ対応した

```lua
-- ビルド前

---$folder:フォルダ
local path = ""

-- ビルド後

--folder@path:フォルダ
```