### PR TITLE
chore: リリースアセットのアーカイブ名に"x64"を追加

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,11 +18,11 @@ jobs:
           - name: Windows
             os: windows-latest
             ext: .exe
-            archive: aulua-${{ github.ref_name }}-windows.zip
+            archive: aulua-${{ github.ref_name }}-windows-x64.zip
           - name: Linux
             os: ubuntu-latest
             ext: ''
-            archive: aulua-${{ github.ref_name }}-linux.tar.gz
+            archive: aulua-${{ github.ref_name }}-linux-x64.tar.gz
 
     runs-on: ${{ matrix.os }}
     defaults:


### PR DESCRIPTION
今後もし対応アーキテクチャが増えたときのために、リリースアセットのアーカイブ名にアーキテクチャを表す `x64` を追加した。