### PR TITLE
feat: package.ini の uninstallSubFolderFile への対応を追加

### DIFF
--- a/schema/aulua.schema.json
+++ b/schema/aulua.schema.json
@@ -144,6 +144,12 @@
             "null"
           ]
         },
+        "uninstall_sub_folder_file": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "version": {
           "type": [
             "string",

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ impl RawConfig {
             name: p.name,
             information: p.information,
             version: p.version,
+            uninstall_sub_folder_file: p.uninstall_sub_folder_file.unwrap_or(false),
             out_dir: p
                 .out_dir
                 .map(|d| config_dir.join(d))
@@ -133,6 +134,7 @@ pub struct RawPackage {
     pub name: Option<String>,
     pub information: Option<String>,
     pub version: Option<String>,
+    pub uninstall_sub_folder_file: Option<bool>,
     pub out_dir: Option<String>,
     pub file_name: Option<String>,
     pub script_sub_dir: Option<String>,
@@ -323,6 +325,7 @@ impl ResolvedConfig {
             name,
             information,
             version: p.version.clone(),
+            uninstall_sub_folder_file: p.uninstall_sub_folder_file,
             out_dir: p.out_dir.clone(),
             file_name,
             script_sub_dir,
@@ -364,6 +367,7 @@ pub struct ResolvedPackage {
     pub name: Option<String>,
     pub information: Option<String>,
     pub version: Option<String>,
+    pub uninstall_sub_folder_file: bool,
     pub out_dir: PathBuf,
     pub file_name: Option<String>,
     pub script_sub_dir: Option<String>,
@@ -402,6 +406,7 @@ pub struct PackConfig {
     pub name: String,
     pub information: String,
     pub version: Option<String>,
+    pub uninstall_sub_folder_file: bool,
     pub out_dir: PathBuf,
     pub file_name: String,
     pub script_sub_dir: String,

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -118,8 +118,8 @@ pub fn pack_project(config: &ResolvedConfig) -> Result<PathBuf> {
 
 fn render_package_ini(pack: &PackConfig) -> String {
     format!(
-        "[package]\r\nid={}\r\nname={}\r\ninformation={}\r\n",
-        pack.id, pack.name, pack.information
+        "[package]\r\nid={}\r\nname={}\r\ninformation={}\r\nuninstallSubFolderFile={}\r\n",
+        pack.id, pack.name, pack.information, pack.uninstall_sub_folder_file as i32
     )
 }
 
@@ -353,6 +353,7 @@ mod tests {
             name: "Example".to_string(),
             information: "Example package".to_string(),
             version: Some("1.2.3".to_string()),
+            uninstall_sub_folder_file: false,
             out_dir: PathBuf::from("dist"),
             file_name: "karoterra.example-v1.2.3.au2pkg.zip".to_string(),
             script_sub_dir: "karoterra.example".to_string(),
@@ -364,7 +365,30 @@ mod tests {
 
         assert_eq!(
             ini,
-            "[package]\r\nid=karoterra.example\r\nname=Example\r\ninformation=Example package\r\n"
+            "[package]\r\nid=karoterra.example\r\nname=Example\r\ninformation=Example package\r\nuninstallSubFolderFile=0\r\n"
+        );
+    }
+
+    #[test]
+    fn render_package_ini_uninstall_sub_folder_file_is_true() {
+        let pack = PackConfig {
+            id: "karoterra.example".to_string(),
+            name: "Example".to_string(),
+            information: "Example package".to_string(),
+            version: Some("1.2.3".to_string()),
+            uninstall_sub_folder_file: true,
+            out_dir: PathBuf::from("dist"),
+            file_name: "karoterra.example-v1.2.3.au2pkg.zip".to_string(),
+            script_sub_dir: "karoterra.example".to_string(),
+            message: None,
+            assets: vec![],
+        };
+
+        let ini = render_package_ini(&pack);
+
+        assert_eq!(
+            ini,
+            "[package]\r\nid=karoterra.example\r\nname=Example\r\ninformation=Example package\r\nuninstallSubFolderFile=1\r\n"
         );
     }
 


### PR DESCRIPTION
Issue #42 への対応

beta41 から `package.ini` に以下のような `uninstallSubFolderFile` 項目が追加された。

```ini
[package]
; パッケージの識別子(ファイル名で利用可能な文字列) ※未設定の場合はパッケージファイルから拡張子(.zip)を除いた文字列
id=SamplePackage
; パッケージの名称 ※インストール、アンインストール等で表示されます
name=サンプルパッケージ
; パッケージの情報 ※インストール、アンインストール等で表示されます
information=サンプルパッケージ ver2.00 by Kenkun
; アンインストール時にサブフォルダのファイル削除指定 ※競合しないPlugin,Script等の一つ下のフォルダのファイルを全て削除対象にする
uninstallSubFolderFile=1
```

aulua でもこれに追従するため、 `aulua.yaml` に `package.uninstall_sub_folder_file` を追加した。
省略時はデフォルト値として `false` ( `uninstallSubFolderFile=0` ) とした。

```yaml
package:
  uninstall_sub_folder_file: true
```