### PR TITLE
chore: NOTICE のプロジェクト名表記を修正

### DIFF
--- a/about.hbs
+++ b/about.hbs
@@ -39,9 +39,9 @@
     <main class="container">
         <div class="intro">
             <h1>Third Party Licenses</h1>
-            <p>This page lists the licenses of the projects used in cargo-about.</p>
+            <p>This page lists the licenses of the projects used in aulua.</p>
         </div>
-    
+
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             {{#each overview}}


### PR DESCRIPTION
NOTICE のプロジェクト名表記がテンプレートのまま `cargo-about` になっていたので `aulua` に修正した。