### PR TITLE
fix: リリースワークフローのcargo-aboutセットアップ方法を修正

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
         run: cargo build --release
 
       - name: Install cargo-about
-        run: cargo install --locked cargo-about
+        run: cargo install --locked cargo-about --features cli
 
       - name: Generate NOTICE.html
         run: cargo about generate about.hbs -o NOTICE.html


### PR DESCRIPTION
v0.9.0 をリリースしようとしたところワークフローが失敗したのでワークフローを修正した。
`cargo-about` v0.9.0 から `cargo install` するときに `cli` feature の指定が必要になったようである。